### PR TITLE
Reapply config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+distribution
+.parcel-cache

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true # Until https://github.com/xojs/stylelint-config-xo/issues/19

--- a/.parcelrc
+++ b/.parcelrc
@@ -1,0 +1,3 @@
+{
+	"extends": "@parcel/config-webextension"
+}

--- a/.terserrc
+++ b/.terserrc
@@ -1,0 +1,7 @@
+{
+	"mangle": false,
+	"output": {
+		"beautify": true,
+		"indent_level": 2
+	}
+}


### PR DESCRIPTION
These config files came from the [https://github.com/fregante/browser-extension-template](browser-extension-template) repository and needed for running the development build locally